### PR TITLE
AQCU 1107 Vertical Datum entry in location details

### DIFF
--- a/src/main/resources/manipulateDataStructure.sh
+++ b/src/main/resources/manipulateDataStructure.sh
@@ -6,6 +6,7 @@ sedArg=" -i.bak -E "
 fi
 
 sed $sedArg 's/type="tns:StatisticalDateTimeOffset"/type="xs:dateTime"/g' $XSD_DIRECTORY/*.xsd
+sed $sedArg 's/type="q[^:]+:Instant"/type="xs:dateTime"/g' $XSD_DIRECTORY/*.xsd
 sed $sedArg 's/type="q[^:]+:DateTimeOffset"/type="xs:dateTime"/g' $XSD_DIRECTORY/*.xsd
 sed $sedArg 's/type="q[^:]+:Offset"/type="xs:string"/g' $XSD_DIRECTORY/*.xsd
 sed $sedArg 's/type="q[^:]+:ArrayOfstring"/type="xs:string" maxOccurs="unbounded"/g' $XSD_DIRECTORY/*.xsd


### PR DESCRIPTION
Issue was caused by q17:Instant being added and not being changed to datetime.